### PR TITLE
Fix #6

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -27,7 +27,7 @@ performance.
 ==== Null Output Configuration Options
 
 There are no special configuration options for this plugin,
-but it does support the <<{version}-plugins-{type}s-{plugin}-common-options>>.
+but it does support the <<plugins-{type}s-{plugin}-common-options>>.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,12 +26,8 @@ performance.
 [id="plugins-{type}s-{plugin}-options"]
 ==== Null Output Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-|=======================================================================
+There are no special configuration options for this plugin,
+but it does support the <<{version}-plugins-{type}s-{plugin}-common-options>>.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
Replaces #6 

{version} can only appear in the versioned plugin reference, and needs to be added through scripting, not to the source repos.
